### PR TITLE
added ordering to smelter traversal

### DIFF
--- a/ConversionSizeSpeed/ConversionSizeSpeed.cs
+++ b/ConversionSizeSpeed/ConversionSizeSpeed.cs
@@ -104,7 +104,7 @@ public class ConversionSizeSpeed : BaseUnityPlugin
 
 		Regex regex = new("""['\["\]]""");
 
-		foreach (Smelter smelter in prefabs.Select(p => p.GetComponent<Smelter>()).Where(s => s != null))
+		foreach (Smelter smelter in prefabs.Select(p => p.GetComponent<Smelter>()).Where(s => s != null).OrderBy(s => s.name))
 		{
 			int order = 0;
 


### PR DESCRIPTION
Without such ordering the order of many custom smelters is unstable. Bigger mod pack like Reforge do have a problem with this, since the order of loading mods and the list traversal will lead to changing "group" numbers, which will completely screw up BepInEx config (Smelters will appear with different numbers and by this render the configs invalid).